### PR TITLE
1.0.15 pod version update (mlkit)

### DIFF
--- a/FlextudioSDK.podspec
+++ b/FlextudioSDK.podspec
@@ -138,6 +138,6 @@ Pod::Spec.new do |spec|
   spec.dependency "Firebase/Installations", '~> 10.29.0'
   spec.dependency "Firebase/Messaging", '~> 10.29.0'
   spec.dependency "SDWebImage", '~> 5.12.6'
-  spec.dependency "GoogleMLKit/BarcodeScanning", '~> 3.2.0'
+  spec.dependency "GoogleMLKit/BarcodeScanning", '~> 6.0.0'
 
 end

--- a/FlextudioSDK/1.0.15/FlextudioSDK.podspec
+++ b/FlextudioSDK/1.0.15/FlextudioSDK.podspec
@@ -73,6 +73,7 @@ Pod::Spec.new do |spec|
     spec.source       = { :git => "https://github.com/FlexSDKCreator/SDK_ios.git", :branch => "main", :tag => "#{spec.version}" }
 
 
+
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #
   #  CocoaPods is smart about how it includes source code. For source files
@@ -137,6 +138,6 @@ Pod::Spec.new do |spec|
   spec.dependency "Firebase/Installations", '~> 10.29.0'
   spec.dependency "Firebase/Messaging", '~> 10.29.0'
   spec.dependency "SDWebImage", '~> 5.12.6'
-  spec.dependency "GoogleMLKit/BarcodeScanning", '~> 3.2.0'
+  spec.dependency "GoogleMLKit/BarcodeScanning", '~> 6.0.0'
 
 end


### PR DESCRIPTION
From. MobileWG
혹시 GoogleMLKit/BarcodeScanning 이거도 6.0.0 버전으로 업데이트 해주실 수 있을까요..
애플에서 privacy manifest가 없는 sdk들이 포함되면 앱 심사를 거절해서요.. 
위에 말씀드린 pod 라이브러리에 종속되어 있는 GTMSessionFetcher랑 GoogltToolBoxForMac도 아래 privacy manifest가 포함되어야 하는 SDK 대상으로 나옵니다..
 
https://developer.apple.com/support/third-party-SDK-requirements/
 